### PR TITLE
[SB][110335796] Initial implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gemspec

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# asset_manifest_helper
+Rails and Sinatra helpers for generating asset URLs from a JSON manifest
+
+## Usage
+
+### Require the gem
+```ruby
+require 'asset_manifest_helper'
+```
+
+### Configuration:
+```ruby
+AssetManifestHelper.configure do |config|
+  # Set paths to JSON manifest files.
+  config.asset_file = 'path/to/webpack-assets.json'
+  config.bundle_file = 'path/to/webpack-bundles.json'
+
+  # Set protocol and domain for asset server.
+  config.protocol = 'http'
+  config.domain = 'www.example.com'
+
+  # Set to true in production to avoid reloading JSON manifest files.
+  # Set to false (the default) in development to pick up changes to manifest files.
+  config.cache = false
+end
+```
+
+### Helper methods:
+```ruby
+asset_url(asset)
+```
+Given an asset name (such as an image filename) returns the full url to the asset.
+If no match in the manifest, returns full url in which the asset name is treated as the path.
+
+```ruby
+style_url(bundle)
+```
+Given a bundle name (such as "main") returns the full url to the CSS bundle.
+If no match in the manifest, returns `nil`.
+
+```ruby
+script_url(bundle)
+```
+Given a bundle name (such as "main") returns the full url to the Javascript bundle.
+If no match in the manifest, returns `nil`.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require "bundler/gem_tasks"
+
+Dir.glob('tasks/**/*.rake').each(&method(:import))
+
+task default: :spec

--- a/asset_manifest_helper.gemspec
+++ b/asset_manifest_helper.gemspec
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+require File.expand_path('../lib/asset_manifest_helper/version', __FILE__)
+require 'date'
+
+Gem::Specification.new do |gem|
+  gem.name        = 'asset_manifest_helper'
+  gem.authors     = ['Sam Brauer', 'RentPath']
+  gem.email       = ['sbrauer@rentpath.com']
+  gem.homepage    = 'https://github.com/rentpath/asset_manifest_helper'
+  gem.description = 'Rails and Sinatra helpers for generating URLs from a JSON manifest'
+  gem.summary     = "Provides helper methods to get full paths and url to (possibly finger-printed) assets from JSON manifest files."
+  gem.version     = AssetManifestHelper::VERSION
+  gem.license     = 'MIT'
+
+  gem.executables = []
+  gem.files       = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec)/}) }
+  gem.require_paths = ['lib']
+  gem.required_ruby_version = '>= 1.9'
+
+  gem.add_development_dependency 'bundler', '~> 1.8'
+  gem.add_development_dependency 'rake', '~> 10.0'
+  gem.add_development_dependency 'rspec', '~> 3.2'
+end

--- a/lib/asset_manifest_helper.rb
+++ b/lib/asset_manifest_helper.rb
@@ -1,0 +1,5 @@
+require_relative 'asset_manifest_helper/configuration'
+require_relative 'asset_manifest_helper/helpers'
+require_relative 'asset_manifest_helper/version'
+require_relative 'asset_manifest_helper/ties/rails' if defined?(Rails)
+require_relative 'asset_manifest_helper/ties/sinatra' if defined?(Sinatra)

--- a/lib/asset_manifest_helper/configuration.rb
+++ b/lib/asset_manifest_helper/configuration.rb
@@ -1,0 +1,56 @@
+require 'json'
+
+module AssetManifestHelper
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
+  def self.reset_configuration
+    @configuration = Configuration.new
+  end
+
+  class Configuration
+    attr_accessor :asset_file, :bundle_file, :cache, :domain, :protocol
+
+    # FIXME: Remove "public/assets/" from default paths? Too opinionated?
+    def initialize(asset_file: 'public/assets/webpack-assets.json',
+                   bundle_file: 'public/assets/webpack-bundles.json',
+                   cache: false,
+                   domain: 'example.com',
+                   protocol: 'http')
+      @asset_file  = asset_file
+      @bundle_file  = bundle_file
+      @cache = cache
+      @domain  = domain
+      @protocol = protocol
+    end
+
+    def asset_manifest
+      if cache
+        @asset_manifest ||= _asset_manifest
+      else
+        _asset_manifest
+      end
+    end
+
+    def bundle_manifest
+      if cache
+        @bundle_manifest ||= _bundle_manifest
+      else
+        _bundle_manifest
+      end
+    end
+
+    def _asset_manifest
+      File.exists?(asset_file) ?  JSON.parse(File.read(asset_file)) : {}
+    end
+
+    def _bundle_manifest
+      File.exists?(bundle_file) ?  JSON.parse(File.read(bundle_file)) : {}
+    end
+  end
+end

--- a/lib/asset_manifest_helper/helpers.rb
+++ b/lib/asset_manifest_helper/helpers.rb
@@ -1,0 +1,31 @@
+module AssetManifestHelper
+  def asset_url(asset)
+    url_for_path(asset_path(asset))
+  end
+
+  def style_url(bundle)
+    url_for_path(style_path(bundle))
+  end
+
+  def script_url(bundle)
+    url_for_path(script_path(bundle))
+  end
+
+  def asset_path(asset)
+    configuration.asset_manifest.fetch(asset, asset)
+  end
+
+  def style_path(bundle)
+    configuration.bundle_manifest.fetch(bundle, {})['css']
+  end
+
+  def script_path(bundle)
+    configuration.bundle_manifest.fetch(bundle, {})['js']
+  end
+
+  def url_for_path(path)
+    return nil unless path
+    separator = path.start_with?('/') ? '' : '/'
+    "#{configuration.protocol}://#{configuration.domain}#{separator}#{path}"
+  end
+end

--- a/lib/asset_manifest_helper/ties/rails.rb
+++ b/lib/asset_manifest_helper/ties/rails.rb
@@ -1,0 +1,7 @@
+module AssetManifestHelper
+  class Railtie < Rails::Railtie
+    initializer "asset_manifest_helper.action_view.add_asset_manifest_helpers" do
+      ActionView::Base.send :include, AssetManifestHelper
+    end
+  end
+end

--- a/lib/asset_manifest_helper/ties/sinatra.rb
+++ b/lib/asset_manifest_helper/ties/sinatra.rb
@@ -1,0 +1,3 @@
+module Sinatra
+  helpers AssetManifestHelper
+end

--- a/lib/asset_manifest_helper/version.rb
+++ b/lib/asset_manifest_helper/version.rb
@@ -1,0 +1,3 @@
+module AssetManifestHelper
+  VERSION = '0.0.1'
+end

--- a/spec/asset_manifest_helper/configuration_spec.rb
+++ b/spec/asset_manifest_helper/configuration_spec.rb
@@ -1,0 +1,84 @@
+require_relative '../../lib/asset_manifest_helper'
+
+describe AssetManifestHelper.configuration do
+  let(:sample_asset_manifest) { { 'foo.png' => '/assets/foo-fingerprint.png' } }
+  let(:sample_bundle_manifest) { { 'main' => { 'js' => '/assets/main-bundle.js', 'css' => '/assets/main-bundle.css' } } }
+
+  before(:each) do
+    AssetManifestHelper.reset_configuration
+  end
+
+  describe '.asset_manifest' do
+    it 'returns empty hash when asset_file missing' do
+      expect(AssetManifestHelper.configuration.asset_manifest).to eql({})
+    end
+
+    it 'returns data from asset_file when present' do
+      AssetManifestHelper.configure do |config|
+        config.asset_file = 'spec/fixtures/assets.json'
+      end
+      expect(AssetManifestHelper.configuration.asset_manifest).to eql(sample_asset_manifest)
+    end
+
+    context 'cache is disabled (default)' do
+      it 'loads the asset_file each time' do
+        expect(AssetManifestHelper.configuration.asset_manifest).to eql({})
+        AssetManifestHelper.configure do |config|
+          config.asset_file = 'spec/fixtures/assets.json'
+        end
+        expect(AssetManifestHelper.configuration.asset_manifest).to eql(sample_asset_manifest)
+      end
+    end
+
+    context 'cache is enabled' do
+      it 'loads the asset_file once' do
+        AssetManifestHelper.configure do |config|
+          config.cache = true
+        end
+        expect(AssetManifestHelper.configuration.asset_manifest).to eql({})
+
+        AssetManifestHelper.configure do |config|
+          config.asset_file = 'spec/fixtures/assets.json'
+        end
+        expect(AssetManifestHelper.configuration.asset_manifest).to eql({})
+      end
+    end
+  end
+
+  describe '.bundle_manifest' do
+    it 'returns empty hash when bundle_file missing' do
+      expect(AssetManifestHelper.configuration.bundle_manifest).to eql({})
+    end
+
+    it 'returns data from bundle_file when present' do
+      AssetManifestHelper.configure do |config|
+        config.bundle_file = 'spec/fixtures/bundles.json'
+      end
+      expect(AssetManifestHelper.configuration.bundle_manifest).to eql(sample_bundle_manifest)
+    end
+
+    context 'cache is disabled (default)' do
+      it 'loads the bundle_file each time' do
+        expect(AssetManifestHelper.configuration.bundle_manifest).to eql({})
+        AssetManifestHelper.configure do |config|
+          config.bundle_file = 'spec/fixtures/bundles.json'
+        end
+        expect(AssetManifestHelper.configuration.bundle_manifest).to eql(sample_bundle_manifest)
+      end
+    end
+
+    context 'cache is enabled' do
+      it 'loads the bundle_file once' do
+        AssetManifestHelper.configure do |config|
+          config.cache = true
+        end
+        expect(AssetManifestHelper.configuration.bundle_manifest).to eql({})
+
+        AssetManifestHelper.configure do |config|
+          config.bundle_file = 'spec/fixtures/bundles.json'
+        end
+        expect(AssetManifestHelper.configuration.bundle_manifest).to eql({})
+      end
+    end
+  end
+end

--- a/spec/asset_manifest_helper/helper_spec.rb
+++ b/spec/asset_manifest_helper/helper_spec.rb
@@ -1,0 +1,51 @@
+require_relative '../../lib/asset_manifest_helper'
+include AssetManifestHelper
+
+describe AssetManifestHelper do
+  before(:each) do
+    AssetManifestHelper.reset_configuration
+    AssetManifestHelper.configure do |config|
+      config.asset_file = 'spec/fixtures/assets.json'
+      config.bundle_file = 'spec/fixtures/bundles.json'
+    end
+  end
+
+  describe '#asset_url' do
+    context 'asset in manifest' do
+      it 'returns url based on path from manifest' do
+        expect(AssetManifestHelper.asset_url('foo.png')).to eql('http://example.com/assets/foo-fingerprint.png')
+      end
+    end
+    context 'asset not in manifest' do
+      it 'returns url based on bare asset' do
+        expect(AssetManifestHelper.asset_url('unknown.png')).to eql('http://example.com/unknown.png')
+      end
+    end
+  end
+
+  describe '#style_url' do
+    context 'bundle in manifest' do
+      it 'returns url based on path from manifest' do
+        expect(AssetManifestHelper.style_url('main')).to eql('http://example.com/assets/main-bundle.css')
+      end
+    end
+    context 'bundle not in manifest' do
+      it 'returns nil' do
+        expect(AssetManifestHelper.style_url('unknown')).to eql(nil)
+      end
+    end
+  end
+
+  describe '#script_url' do
+    context 'bundle in manifest' do
+      it 'returns url based on path from manifest' do
+        expect(AssetManifestHelper.script_url('main')).to eql('http://example.com/assets/main-bundle.js')
+      end
+    end
+    context 'bundle not in manifest' do
+      it 'returns nil' do
+        expect(AssetManifestHelper.script_url('unknown')).to eql(nil)
+      end
+    end
+  end
+end

--- a/spec/fixtures/assets.json
+++ b/spec/fixtures/assets.json
@@ -1,0 +1,3 @@
+{
+  "foo.png": "/assets/foo-fingerprint.png"
+}

--- a/spec/fixtures/bundles.json
+++ b/spec/fixtures/bundles.json
@@ -1,0 +1,6 @@
+{
+  "main": {
+    "js": "/assets/main-bundle.js",
+    "css": "/assets/main-bundle.css"
+  }
+}

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -1,0 +1,3 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/110335796

A Ruby gem for producing urls based on JSON manifest files.

The story mentioned a method `image_url` but I opted for the more generic name `asset_url` instead.
Not sure whether or not to add `_tag` methods as well (similar to https://github.com/rentpath/tautline/blob/master/lib/tautline/view_helpers/asset_tags.rb).