### PR TITLE
[SB][110335796] Access helper methods via #manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ require 'asset_manifest_helper'
 ### Configuration:
 ```ruby
 AssetManifestHelper.configure do |config|
-  # Set paths to JSON manifest files.
+  # Set paths to JSON manifest files. Defaults are in 'public/assets/'
   config.asset_file = 'path/to/webpack-assets.json'
   config.bundle_file = 'path/to/webpack-bundles.json'
 
@@ -26,20 +26,41 @@ end
 ```
 
 ### Helper methods:
+All of the helper methods are accessed through a single method `#manifest`.
+It acts as a sort of namespace.
+
 ```ruby
-asset_url(asset)
+manifest.asset_url(asset)
 ```
 Given an asset name (such as an image filename) returns the full url to the asset.
 If no match in the manifest, returns full url in which the asset name is treated as the path.
 
 ```ruby
-style_url(bundle)
+manifest.style_url(bundle)
 ```
 Given a bundle name (such as "main") returns the full url to the CSS bundle.
 If no match in the manifest, returns `nil`.
 
 ```ruby
-script_url(bundle)
+manifest.script_url(bundle)
 ```
 Given a bundle name (such as "main") returns the full url to the Javascript bundle.
+If no match in the manifest, returns `nil`.
+
+```ruby
+manifest.asset_path(asset)
+```
+Given an asset name (such as an image filename) returns the path to the asset from the manifest file.
+If no match in the manifest, returns `asset`.
+
+```ruby
+manifest.style_path(bundle)
+```
+Given a bundle name (such as "main") returns the path to the CSS bundle.
+If no match in the manifest, returns `nil`.
+
+```ruby
+manifest.script_path(bundle)
+```
+Given a bundle name (such as "main") returns the path to the Javascript bundle.
 If no match in the manifest, returns `nil`.

--- a/lib/asset_manifest_helper/helpers.rb
+++ b/lib/asset_manifest_helper/helpers.rb
@@ -1,35 +1,45 @@
 module AssetManifestHelper
-  def asset_url(asset)
-    url_for_path(asset_path(asset))
+  def manifest
+    @manifest ||= Manifest.new
   end
 
-  def style_url(bundle)
-    url_for_path(style_path(bundle))
-  end
+  class Manifest
+    def asset_url(asset)
+      url_for_path(asset_path(asset))
+    end
 
-  def script_url(bundle)
-    url_for_path(script_path(bundle))
-  end
+    def style_url(bundle)
+      url_for_path(style_path(bundle))
+    end
 
-  def asset_path(asset)
-    AssetManifestHelper.configuration.asset_manifest.fetch(asset, asset)
-  end
+    def script_url(bundle)
+      url_for_path(script_path(bundle))
+    end
 
-  def style_path(bundle)
-    AssetManifestHelper.configuration.bundle_manifest.fetch(bundle, {})['css']
-  end
+    def asset_path(asset)
+      configuration.asset_manifest.fetch(asset, asset)
+    end
 
-  def script_path(bundle)
-    AssetManifestHelper.configuration.bundle_manifest.fetch(bundle, {})['js']
-  end
+    def style_path(bundle)
+      configuration.bundle_manifest.fetch(bundle, {})['css']
+    end
 
-  def url_for_path(path)
-    return nil unless path
-    separator = path.start_with?('/') ? '' : '/'
-    "#{asset_root_url}#{separator}#{path}"
-  end
+    def script_path(bundle)
+      configuration.bundle_manifest.fetch(bundle, {})['js']
+    end
 
-  def asset_root_url
-    "#{AssetManifestHelper.configuration.protocol}://#{AssetManifestHelper.configuration.domain}"
+    def url_for_path(path)
+      return nil unless path
+      separator = path.start_with?('/') ? '' : '/'
+      "#{asset_root_url}#{separator}#{path}"
+    end
+
+    def asset_root_url
+      "#{configuration.protocol}://#{configuration.domain}"
+    end
+
+    def configuration
+      AssetManifestHelper.configuration
+    end
   end
 end

--- a/spec/asset_manifest_helper/helper_spec.rb
+++ b/spec/asset_manifest_helper/helper_spec.rb
@@ -10,48 +10,48 @@ describe AssetManifestHelper do
     end
   end
 
-  describe '#asset_url' do
+  describe '#manifest.asset_url' do
     context 'asset in manifest' do
       it 'returns url based on path from manifest' do
-        expect(AssetManifestHelper.asset_url('foo.png')).to eql('http://example.com/assets/foo-fingerprint.png')
+        expect(manifest.asset_url('foo.png')).to eql('http://example.com/assets/foo-fingerprint.png')
       end
     end
     context 'asset not in manifest' do
       it 'returns url based on bare asset' do
-        expect(AssetManifestHelper.asset_url('unknown.png')).to eql('http://example.com/unknown.png')
+        expect(manifest.asset_url('unknown.png')).to eql('http://example.com/unknown.png')
       end
     end
   end
 
-  describe '#style_url' do
+  describe '#manifest.style_url' do
     context 'bundle in manifest' do
       it 'returns url based on path from manifest' do
-        expect(AssetManifestHelper.style_url('main')).to eql('http://example.com/assets/main-bundle.css')
+        expect(manifest.style_url('main')).to eql('http://example.com/assets/main-bundle.css')
       end
     end
     context 'bundle not in manifest' do
       it 'returns nil' do
-        expect(AssetManifestHelper.style_url('unknown')).to eql(nil)
+        expect(manifest.style_url('unknown')).to eql(nil)
       end
     end
   end
 
-  describe '#script_url' do
+  describe '#manifest.script_url' do
     context 'bundle in manifest' do
       it 'returns url based on path from manifest' do
-        expect(AssetManifestHelper.script_url('main')).to eql('http://example.com/assets/main-bundle.js')
+        expect(manifest.script_url('main')).to eql('http://example.com/assets/main-bundle.js')
       end
     end
     context 'bundle not in manifest' do
       it 'returns nil' do
-        expect(AssetManifestHelper.script_url('unknown')).to eql(nil)
+        expect(manifest.script_url('unknown')).to eql(nil)
       end
     end
   end
 
-  describe '#asset_root_url' do
+  describe '#manifest.asset_root_url' do
     it 'returns url based on configured protocol and domain' do
-        expect(AssetManifestHelper.asset_root_url).to eql('http://example.com')
+        expect(manifest.asset_root_url).to eql('http://example.com')
     end
   end
 end


### PR DESCRIPTION
Since helper methods are combined into one namespace, we encountered
collisions in a Rails app with various helper methods from
ActionView::Helpers::AssetUrlHelper (asset_path, asset_url, etc).

With this change we expose a single helper method #manifest which
returns an object that responds to the original helper methods
(#asset_url, etc).