### PR TITLE
[CW] [116161761] Expose #manifest as a module_function

### DIFF
--- a/lib/asset_manifest_helper/helpers.rb
+++ b/lib/asset_manifest_helper/helpers.rb
@@ -2,6 +2,7 @@ module AssetManifestHelper
   def manifest
     @manifest ||= Manifest.new
   end
+  module_function :manifest
 
   class Manifest
     def asset_url(asset)

--- a/spec/asset_manifest_helper/helper_spec.rb
+++ b/spec/asset_manifest_helper/helper_spec.rb
@@ -10,6 +10,12 @@ describe AssetManifestHelper do
     end
   end
 
+  describe '#manifest' do
+    it 'is included as a module function' do
+      expect(AssetManifestHelper.manifest.class).to eql(manifest.class)
+    end
+  end
+
   describe '#manifest.asset_url' do
     context 'asset in manifest' do
       it 'returns url based on path from manifest' do


### PR DESCRIPTION
This allows devs to use `AssetManifestHelper.manifest.asset_url()` in places outside of views.

/cc @sbrauer 