### PR TITLE
[MEN][137639621] remove protocol from asset path

### DIFF
--- a/lib/asset_manifest_helper/helpers.rb
+++ b/lib/asset_manifest_helper/helpers.rb
@@ -36,7 +36,13 @@ module AssetManifestHelper
     end
 
     def asset_root_url
-      "#{configuration.protocol}://#{configuration.domain}"
+      "#{asset_protocol}//#{configuration.domain}"
+    end
+
+    def asset_protocol
+      if configuration.protocol
+       "#{configuration.protocol}:"
+      end
     end
 
     def configuration

--- a/lib/asset_manifest_helper/version.rb
+++ b/lib/asset_manifest_helper/version.rb
@@ -1,3 +1,3 @@
 module AssetManifestHelper
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/spec/asset_manifest_helper/helper_spec.rb
+++ b/spec/asset_manifest_helper/helper_spec.rb
@@ -60,4 +60,25 @@ describe AssetManifestHelper do
         expect(manifest.asset_root_url).to eql('http://example.com')
     end
   end
+
+  describe '#manifest.asset_protocol' do
+    it 'returns script url set to https' do
+        AssetManifestHelper.configure do |config|
+          config.protocol = "https"
+        end
+        expect(manifest.script_url('main')).to eql('https://example.com/assets/main-bundle.js')
+    end
+    it 'returns script url set to http' do
+        AssetManifestHelper.configure do |config|
+          config.protocol = 'http'
+        end
+        expect(manifest.script_url('main')).to eql('http://example.com/assets/main-bundle.js')
+    end
+  end
+    it 'returns script url set to //' do
+        AssetManifestHelper.configure do |config|
+          config.protocol = false
+        end
+        expect(manifest.script_url('main')).to eql('//example.com/assets/main-bundle.js')
+    end
 end


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/137639621)

<del>
This PR adds a flag to remove the protocol from the asset URL. It defaults to false to stay backwards compatible.
This PR defaults the protocol to ```//:```
</del>


Setting ```configuration.protocol``` to ```false``` adds ```//``` as protocol